### PR TITLE
修复当re_password为空，password不为空时，返回的JSON数据不正确的问题

### DIFF
--- a/bluebell/controller/validator.go
+++ b/bluebell/controller/validator.go
@@ -77,7 +77,10 @@ func removeTopStruct(fields map[string]string) map[string]string {
 // SignUpParamStructLevelValidation 自定义SignUpParam结构体校验函数
 func SignUpParamStructLevelValidation(sl validator.StructLevel) {
 	su := sl.Current().Interface().(models.ParamSignUp)
-
+	// 校验RePassword为空时返回，否则RePassword为空时，并不执行required校验规则
+	if len(su.RePassword) == 0 {
+		return
+	}
 	if su.Password != su.RePassword {
 		// 输出错误提示信息，最后一个参数就是传递的param
 		sl.ReportError(su.RePassword, "re_password", "RePassword", "eqfield", "password")


### PR DESCRIPTION
修复当re_password为空，password不为空时，返回的JSON数据："re_password必须等于password"，而不是"re_password为必填字段"的问题